### PR TITLE
Fix ZipException when receiving from certain devices

### DIFF
--- a/app/src/main/java/moe/reimu/catshare/utils/ZipPathValidatorCallback.kt
+++ b/app/src/main/java/moe/reimu/catshare/utils/ZipPathValidatorCallback.kt
@@ -1,0 +1,14 @@
+package moe.reimu.catshare.utils
+
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import dalvik.system.ZipPathValidator.Callback
+
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+object ZipPathValidatorCallback : Callback {
+    override fun onZipEntryAccess(path: String) {
+        Log.d(TAG, path)
+        super.onZipEntryAccess(path)
+    }
+}


### PR DESCRIPTION
When receiving from some devices, a device with Android API version `>= 34` will throw a `ZipException` because the zip path starts with `/`. This is caused by [the zip path validation introduced in Android 14](https://developer.android.com/about/versions/14/behavior-changes-14?hl=zh-cn#zip-path-traversal).

To handle this issue, a `ZipPathValidatorCallback` that only logs the path is added to ignore the default check. For some potential security issues I didn't adopt the `clearCallback()` method.

---

从某些设备接收时，Android API 版本`>= 34` 的设备会抛出`ZipException`，因为压缩路径以`/`开头（注：某些设备发送的Zip中使用绝对路径）。这是由于[Android 14 中引入的压缩路径验证](https://developer.android.com/about/versions/14/behavior-changes-14?hl=zh-cn#zip-path-traversal)造成的。

为了处理这个问题，我添加了一个只输出Zip路径到日志的 `ZipPathValidatorCallback` 来忽略默认检查。考虑到一些潜在的安全问题，我没有采用 `clearCallback()` 方法。