### PR TITLE
修复在磁铁打开接收服务无法连接p2p

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
     <uses-permission
         android:name="android.permission.ACCESS_FINE_LOCATION"
         android:maxSdkVersion="32" />
+    <uses-permission 
+        android:name="android.permission.ACCESS_BACKGROUND_LOCATION"Add commentMore actions
+        android:maxSdkVersion="32" />
     <uses-permission
         android:name="android.permission.ACCESS_WIFI_STATE"
         android:required="true" />


### PR DESCRIPTION
添加后台使用位置的权限声明
已经测试过成功接收文件，但是出现了一个新的错误通知
![IMG_20250615_062601](https://github.com/user-attachments/assets/28f09b15-20a8-41e8-9ce1-44f425c0fd3c)
[logcat.txt](https://github.com/user-attachments/files/20742760/logcat.txt)
超过我能力范围了